### PR TITLE
Remove default exports

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,11 +2,11 @@ import * as fs from 'fs';
 import { Mongoose } from "mongoose";
 //import { insertDummyData } from './dummyData';
 import { registerExpressRoutes } from './lib/registerExpressRoutes';
-import createExpressServer from './lib/createExpressServer';
 import { config } from './config';
 import { User } from './models/user/user.model';
 import { insertDummyData } from './insertDummyData';
 import * as del from "del";
+import { createExpressServer } from './lib/createExpressServer';
 
 const mongoose: Mongoose = require("mongoose");
 

--- a/backend/src/endpoints/getDocumentFile.ts
+++ b/backend/src/endpoints/getDocumentFile.ts
@@ -4,17 +4,13 @@ import { generateFilePath } from '../lib/generateFilePath';
 import * as mongoose from 'mongoose';
 
 export default async function getDocumentFile(req: any, res: any) {
-    console.log("Address line:", req.originalUrl);
     const documentId: mongoose.Types.ObjectId = req.params.docID;
     if(documentId == null) {
         res.status(400).send();
         return;
     }
 
-    console.log("DocID:", documentId);
     const doc: IDocument = await Document.findById(documentId, 'title fileExtension user_R number');
-    console.log(doc);
-    console.log("Selected fields:", doc.toString());
     const filepath = generateFilePath(doc);
     res.download(filepath, `${doc.title}.${doc.fileExtension}`);
 }

--- a/backend/src/endpoints/uploadSingleDocument.ts
+++ b/backend/src/endpoints/uploadSingleDocument.ts
@@ -3,12 +3,11 @@ import * as mongoose from 'mongoose';
 import { Request, Response } from "express";
 import { Document } from "../models/document/document.model";
 import { User } from "../models/user/user.model";
-import { Tag } from "../models/tag/tag.model";
 import { getNextPrimaryNumber } from "../lib/getNextPrimaryNumber";
 import { getUserIDFromJWT } from "../lib/getUserIDFromJWT";
 import { generateFilePath } from "../lib/generateFilePath";
-import extractFileExtension from "../lib/extractFileExtension";
 import { IDocument } from "../models/document/document.interface";
+import { extractFileExtension } from "../lib/extractFileExtension";
 
 /*interface IRequestTag {
     name: string;

--- a/backend/src/lib/createExpressServer.ts
+++ b/backend/src/lib/createExpressServer.ts
@@ -3,7 +3,7 @@ import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as http from 'http';
 
-export default function createExpressServer() {
+export function createExpressServer() {
     const app = express();
     const server = http.createServer(app);
     app.use(bodyParser.json());

--- a/backend/src/lib/extractFileExtension.ts
+++ b/backend/src/lib/extractFileExtension.ts
@@ -1,3 +1,3 @@
-export default function extractFileExtension(fileName: string): string {
+export function extractFileExtension(fileName: string): string {
     return fileName.split(".").pop();
 }

--- a/backend/src/lib/registerExpressRoutes.ts
+++ b/backend/src/lib/registerExpressRoutes.ts
@@ -1,10 +1,14 @@
 import login from "../endpoints/login";
 import uploadSingleDocument from "../endpoints/uploadSingleDocument";
 import getDocumentFile from "../endpoints/getDocumentFile";
-import validateJWT from "./validateJWT";
 import getAllTags from "../endpoints/getAllTags";
 import getDocument from "../endpoints/getDocument";
-import { searchDocuments } from "../endpoints/searchDocuments";
+import searchDocuments from "../endpoints/searchDocuments";
+import createTag from "../endpoints/createTag";
+import updateTag from "../endpoints/updateTag";
+import deleteTag from "../endpoints/deleteTag";
+import { validateJWT } from "./validateJWT";
+
 const multer = require('multer');
 const upload = multer({ storage: multer.memoryStorage() });
 

--- a/backend/src/lib/validateJWT.ts
+++ b/backend/src/lib/validateJWT.ts
@@ -2,7 +2,7 @@ import * as jwt from 'jsonwebtoken';
 import { Request, Response } from 'express';
 import { config } from '../config';
 
-export default function validateJWT(req: Request, res: Response, next: Function): boolean | void {
+export function validateJWT(req: Request, res: Response, next: Function): boolean | void {
     let token = "";
 
     if(req.headers.token == null && req.query.token == null) {


### PR DESCRIPTION
Closes #62 
I removed all default exports from our library functions because we are planning to merge them into related library files (e.g.: JWT, File, ...). Currently we have one function per file.